### PR TITLE
[3.1.0-2] Get app package for Android Screenshots 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti-appium",
-  "version": "3.1.0-1",
+  "version": "3.1.0-2",
   "description": "An Appium wrapper to test Titanium applications",
   "repository": {
     "type": "git",

--- a/src/webdriver.js
+++ b/src/webdriver.js
@@ -803,7 +803,7 @@ class WebDriver_Helper {
 				case 'Android':
 
 					const capabilities = await driver.sessionCapabilities();
-					const decorName = `${capabilities.appPackage}:id/decor_content_parent`
+					const decorName = `${capabilities.appPackage}:id/decor_content_parent`;
 
 					const elements = await driver.elementsById(decorName);
 

--- a/src/webdriver.js
+++ b/src/webdriver.js
@@ -801,12 +801,16 @@ class WebDriver_Helper {
 					}
 
 				case 'Android':
-					const elements = await driver.elementsById('decor_content_parent');
+
+					const capabilities = await driver.sessionCapabilities();
+					const decorName = `${capabilities.appPackage}:id/decor_content_parent`
+
+					const elements = await driver.elementsById(decorName);
 
 					if (elements.length > 0) {
 						// Get the size of the window frame
 						const bounds = await driver
-							.elementById('decor_content_parent')
+							.elementById(decorName)
 							.getBounds();
 
 						// Create the config for PNGCrop to use


### PR DESCRIPTION
Fixes an error seen in the latest Appium version where `decor_content_parent` Needs to be set. 

Ticket: https://jira.axway.com/browse/QE-4389